### PR TITLE
fix(api): autoriser section_id=0 (Non classé) à l'édition d'un produit

### DIFF
--- a/api/app/Http/Controllers/ProductController.php
+++ b/api/app/Http/Controllers/ProductController.php
@@ -109,7 +109,8 @@ class ProductController extends Controller
             'to_buy' => 'boolean',
             'is_temporary' => 'boolean',
             'comment' => 'nullable|string',
-            'section_id' => 'nullable|integer|exists:sections,id',
+            // 0 is the virtual "Non classé" section, so we skip the exists check for it.
+            'section_id' => 'nullable|integer|exclude_if:section_id,0|exists:sections,id',
         ]);
 
         // Begin a transaction
@@ -156,7 +157,8 @@ class ProductController extends Controller
             'to_buy' => 'boolean',
             'is_temporary' => 'boolean',
             'comment' => 'nullable|string',
-            'section_id' => 'nullable|integer|exists:sections,id',
+            // 0 is the virtual "Non classé" section, so we skip the exists check for it.
+            'section_id' => 'nullable|integer|exclude_if:section_id,0|exists:sections,id',
         ]);
 
         if($request->has('name')) {

--- a/api/tests/Feature/ProductControllerTest.php
+++ b/api/tests/Feature/ProductControllerTest.php
@@ -210,6 +210,45 @@ class ProductControllerTest extends TestCase
         $this->assertTrue($section_autre_store->products()->where('products.id', $product->id)->exists());
     }
 
+    public function test_update_remet_le_produit_en_non_classe_quand_section_id_vaut_zero(): void
+    {
+        [$user, $store] = $this->creer_magasin_courant();
+        $this->authentifier($user);
+        $ancienne_section = Section::factory()->for($store)->create();
+        $autre_store = Store::factory()->for($user)->create();
+        $section_autre_store = Section::factory()->for($autre_store)->create();
+        $product = Product::factory()->for($user)->create(['name' => 'lait']);
+
+        $ancienne_section->products()->attach($product->id);
+        $section_autre_store->products()->attach($product->id);
+
+        // 0 is the virtual "Non classé" section: it must be accepted and detach
+        // the product from the current store sections without triggering the
+        // "section_id sélectionné invalide" validation error.
+        $this->patchJson("/api/products/{$product->id}", [
+            'name' => 'beurre',
+            'section_id' => 0,
+        ])
+            ->assertCreated()
+            ->assertJsonPath('product.name', 'Beurre');
+
+        $this->assertFalse($ancienne_section->products()->where('products.id', $product->id)->exists());
+        $this->assertTrue($section_autre_store->products()->where('products.id', $product->id)->exists());
+    }
+
+    public function test_update_rejette_une_section_id_inexistante(): void
+    {
+        [$user] = $this->creer_magasin_courant();
+        $this->authentifier($user);
+        $product = Product::factory()->for($user)->create();
+
+        $this->patchJson("/api/products/{$product->id}", [
+            'section_id' => 999999,
+        ])
+            ->assertStatus(422)
+            ->assertJsonValidationErrors('section_id');
+    }
+
     public function test_update_efface_le_commentaire_quand_le_produit_est_coche(): void
     {
         [$user] = $this->creer_magasin_courant();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problème

À l'enregistrement de l'édition d'un produit « Non classé » (sans rayon dans le magasin courant), l'API renvoie l'erreur de validation **« le champ section id sélectionné est invalide »**.

## Cause

Le rayon virtuel « Non classé » / « Aucun rayon » est représenté côté frontend par `section_id = 0` (cf. `SectionSelect.vue` et la valeur par défaut de `productForm.js`). Le formulaire d'édition envoie l'objet produit complet, donc `section_id: 0`.

Or la validation du contrôleur utilisait :

```php
'section_id' => 'nullable|integer|exists:sections,id',
```

La règle `exists:sections,id` rejette `0` car aucun rayon n'a l'id 0. Pourtant, la logique du contrôleur traite explicitement `section_id = 0` comme un cas valide : il faut cette valeur pour détacher le produit de ses rayons du magasin courant et le remettre en « Non classé ». La validation bloquait donc une valeur dont le backend a besoin.

## Solution

Ignorer la vérification `exists` lorsque `section_id` vaut `0`, tout en la conservant pour les vrais identifiants de rayon :

```php
'section_id' => 'nullable|integer|exclude_if:section_id,0|exists:sections,id',
```

Le correctif est appliqué aux méthodes `store` et `update` pour rester cohérent.

## Tests

Ajout de deux tests dans `ProductControllerTest` :
- `test_update_remet_le_produit_en_non_classe_quand_section_id_vaut_zero` : vérifie que `section_id = 0` est accepté et détache bien le produit des rayons du magasin courant (sans toucher aux rayons des autres magasins).
- `test_update_rejette_une_section_id_inexistante` : vérifie que la validation `exists` rejette toujours un id de rayon inexistant.

Suite complète `ProductControllerTest` : **15 tests passants (72 assertions)**.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cc04bab4-f8ff-4567-ba9e-9cd54e3f7817"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cc04bab4-f8ff-4567-ba9e-9cd54e3f7817"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

