### PR TITLE
feat: recettes publiques partageables via lien

### DIFF
--- a/api/app/Http/Controllers/PublicRecipeController.php
+++ b/api/app/Http/Controllers/PublicRecipeController.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Http\Resources\PublicRecipeResource;
+use App\Models\Recipe;
+
+class PublicRecipeController extends Controller
+{
+    /**
+     * Display a published recipe from its public share token.
+     *
+     * This endpoint is intentionally unauthenticated. A missing or unpublished
+     * recipe returns a 404 so the existence of private recipes is never leaked.
+     */
+    public function show(string $token)
+    {
+        $recipe = Recipe::query()
+            ->public()
+            ->where('public_token', $token)
+            ->with(['products', 'tags'])
+            ->firstOrFail();
+
+        return new PublicRecipeResource($recipe);
+    }
+}

--- a/api/app/Http/Controllers/RecipeController.php
+++ b/api/app/Http/Controllers/RecipeController.php
@@ -108,6 +108,32 @@ class RecipeController extends Controller
     }
 
     /**
+     * Publish a recipe so it becomes accessible through its share link.
+     */
+    public function publish(Recipe $recipe)
+    {
+        $recipe->publish();
+
+        return response()->json([
+            'is_public' => $recipe->is_public,
+            'public_token' => $recipe->public_token,
+        ]);
+    }
+
+    /**
+     * Unpublish a recipe, revoking public access while keeping its token.
+     */
+    public function unpublish(Recipe $recipe)
+    {
+        $recipe->unpublish();
+
+        return response()->json([
+            'is_public' => $recipe->is_public,
+            'public_token' => $recipe->public_token,
+        ]);
+    }
+
+    /**
      * Count the number of recipes to make
      *
      * @return int

--- a/api/app/Http/Resources/PublicRecipeResource.php
+++ b/api/app/Http/Resources/PublicRecipeResource.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * Public, read-only view of a recipe.
+ *
+ * Exposes only the fields that are safe to share publicly and deliberately
+ * omits private data such as user_id, to_make, the share token, and the
+ * shopping-list state of the ingredients (to_buy, comment).
+ */
+class PublicRecipeResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'name' => $this->name,
+            'description' => $this->description,
+            'link' => $this->link,
+            'products' => $this->whenLoaded('products', function () {
+                return $this->products->map(function ($product) {
+                    return [
+                        'name' => $product->name,
+                        'quantity' => $product->pivot->quantity ?? null,
+                    ];
+                })->values();
+            }),
+            'tags' => $this->whenLoaded('tags', function () {
+                return $this->tags->map(fn ($tag) => [
+                    'name' => $tag->name,
+                ])->values();
+            }),
+        ];
+    }
+}

--- a/api/app/Models/Recipe.php
+++ b/api/app/Models/Recipe.php
@@ -2,8 +2,10 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Str;
 
 class Recipe extends Model
 {
@@ -15,11 +17,52 @@ class Recipe extends Model
         'user_id',
         'link',
         'to_make',
+        'is_public',
+    ];
+
+    protected $casts = [
+        'to_make' => 'boolean',
+        'is_public' => 'boolean',
     ];
 
     public function user()
     {
         return $this->belongsTo(User::class);
+    }
+
+    /**
+     * Only recipes explicitly published by their owner.
+     */
+    public function scopePublic(Builder $query): Builder
+    {
+        return $query->where('is_public', true);
+    }
+
+    /**
+     * Publish the recipe and generate a share token if missing.
+     */
+    public function publish(): self
+    {
+        $this->is_public = true;
+
+        if (empty($this->public_token)) {
+            $this->public_token = (string) Str::uuid();
+        }
+
+        $this->save();
+
+        return $this;
+    }
+
+    /**
+     * Unpublish the recipe while keeping its token for later reuse.
+     */
+    public function unpublish(): self
+    {
+        $this->is_public = false;
+        $this->save();
+
+        return $this;
     }
 
     public function products()

--- a/api/database/factories/RecipeFactory.php
+++ b/api/database/factories/RecipeFactory.php
@@ -5,6 +5,7 @@ namespace Database\Factories;
 use App\Models\Recipe;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
 
 /**
  * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Recipe>
@@ -26,6 +27,19 @@ class RecipeFactory extends Factory
             'link' => fake()->optional()->url(),
             'user_id' => User::factory(),
             'to_make' => fake()->boolean(),
+            'is_public' => false,
+            'public_token' => null,
         ];
+    }
+
+    /**
+     * State for a published (publicly shareable) recipe.
+     */
+    public function public(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'is_public' => true,
+            'public_token' => (string) Str::uuid(),
+        ]);
     }
 }

--- a/api/database/migrations/2026_07_05_093000_add_public_fields_to_recipes_table.php
+++ b/api/database/migrations/2026_07_05_093000_add_public_fields_to_recipes_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('recipes', function (Blueprint $table) {
+            $table->boolean('is_public')->default(false)->index()->after('to_make');
+            // Non-guessable public token to avoid recipe id enumeration.
+            $table->uuid('public_token')->nullable()->unique()->after('is_public');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('recipes', function (Blueprint $table) {
+            $table->dropColumn(['is_public', 'public_token']);
+        });
+    }
+};

--- a/api/routes/api.php
+++ b/api/routes/api.php
@@ -8,6 +8,7 @@ use App\Http\Controllers\StoreController;
 use App\Http\Controllers\ProductController;
 use App\Http\Controllers\SectionController;
 use App\Http\Controllers\RecipeController;
+use App\Http\Controllers\PublicRecipeController;
 use App\Http\Controllers\TagController;
 
 /*
@@ -124,6 +125,11 @@ Route::middleware('auth:sanctum', 'verified')->group(function() {
         // Delete a recipe
         Route::delete('/recipes/{recipe}', [RecipeController::class, 'destroy']);
 
+        // Publish a recipe (make it publicly shareable)
+        Route::post('/recipes/{recipe}/publish', [RecipeController::class, 'publish']);
+        // Unpublish a recipe
+        Route::delete('/recipes/{recipe}/publish', [RecipeController::class, 'unpublish']);
+
         // Sync recipe tags
         Route::put('/recipes/{recipe}/tags', [RecipeController::class, 'syncTags']);
 
@@ -145,6 +151,9 @@ Route::middleware('auth:sanctum', 'verified')->group(function() {
 
 
 });
+
+// Public (unauthenticated) access to a shared recipe via its token
+Route::get('/public/recipes/{token}', [PublicRecipeController::class, 'show']);
 
 // Override the default route for password reset
 Route::get('/reset-password/{token}', function (string $token) {

--- a/api/tests/Feature/PublicRecipeTest.php
+++ b/api/tests/Feature/PublicRecipeTest.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Product;
+use App\Models\Recipe;
+use App\Models\Tag;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Feature\Concerns\CreatesGriotteData;
+use Tests\TestCase;
+
+class PublicRecipeTest extends TestCase
+{
+    use CreatesGriotteData;
+    use RefreshDatabase;
+
+    public function test_publish_rend_la_recette_publique_et_genere_un_token(): void
+    {
+        $user = $this->authentifier();
+        $recipe = Recipe::factory()->for($user)->create(['is_public' => false, 'public_token' => null]);
+
+        $response = $this->postJson("/api/recipes/{$recipe->id}/publish")
+            ->assertOk()
+            ->assertJsonPath('is_public', true);
+
+        $token = $response->json('public_token');
+        $this->assertNotEmpty($token);
+
+        $this->assertDatabaseHas('recipes', [
+            'id' => $recipe->id,
+            'is_public' => true,
+            'public_token' => $token,
+        ]);
+    }
+
+    public function test_publish_conserve_le_token_existant(): void
+    {
+        $user = $this->authentifier();
+        $recipe = Recipe::factory()->for($user)->public()->create();
+        $token_initial = $recipe->public_token;
+
+        $recipe->unpublish();
+
+        $this->postJson("/api/recipes/{$recipe->id}/publish")
+            ->assertOk()
+            ->assertJsonPath('public_token', $token_initial);
+    }
+
+    public function test_unpublish_revoque_l_acces_public_sans_supprimer_le_token(): void
+    {
+        $user = $this->authentifier();
+        $recipe = Recipe::factory()->for($user)->public()->create();
+        $token = $recipe->public_token;
+
+        $this->deleteJson("/api/recipes/{$recipe->id}/publish")
+            ->assertOk()
+            ->assertJsonPath('is_public', false)
+            ->assertJsonPath('public_token', $token);
+
+        $this->assertDatabaseHas('recipes', [
+            'id' => $recipe->id,
+            'is_public' => false,
+            'public_token' => $token,
+        ]);
+    }
+
+    public function test_publish_refuse_une_recette_d_un_autre_utilisateur(): void
+    {
+        $this->authentifier();
+        $autre_user = User::factory()->create();
+        $recipe = Recipe::factory()->for($autre_user)->create();
+
+        $this->postJson("/api/recipes/{$recipe->id}/publish")
+            ->assertForbidden()
+            ->assertJsonPath('message', 'This resource does not belong to the authenticated user.');
+
+        $this->assertDatabaseHas('recipes', [
+            'id' => $recipe->id,
+            'is_public' => false,
+        ]);
+    }
+
+    public function test_acces_public_a_une_recette_publiee_renvoie_les_donnees_filtrees(): void
+    {
+        $owner = User::factory()->create();
+        $recipe = Recipe::factory()->for($owner)->public()->create([
+            'name' => 'Tarte aux pommes',
+            'description' => 'Étaler la pâte',
+            'link' => 'https://example.test/tarte',
+        ]);
+        $tag = Tag::factory()->for($owner)->create(['name' => 'Dessert']);
+        $recipe->tags()->attach($tag->id);
+        $product = Product::factory()->for($owner)->create([
+            'name' => 'Pomme',
+            'to_buy' => true,
+            'comment' => 'note privée',
+        ]);
+        $recipe->products()->attach($product->id, ['quantity' => '4']);
+
+        $response = $this->getJson("/api/public/recipes/{$recipe->public_token}")
+            ->assertOk()
+            ->assertJsonPath('data.name', 'Tarte aux pommes')
+            ->assertJsonPath('data.description', 'Étaler la pâte')
+            ->assertJsonPath('data.link', 'https://example.test/tarte')
+            ->assertJsonPath('data.products.0.name', 'Pomme')
+            ->assertJsonPath('data.products.0.quantity', '4')
+            ->assertJsonPath('data.tags.0.name', 'Dessert');
+
+        // Aucune donnée privée ne doit fuiter.
+        $contenu = $response->getContent();
+        $this->assertStringNotContainsString('user_id', $contenu);
+        $this->assertStringNotContainsString('to_make', $contenu);
+        $this->assertStringNotContainsString('to_buy', $contenu);
+        $this->assertStringNotContainsString('public_token', $contenu);
+        $this->assertStringNotContainsString('note privée', $contenu);
+    }
+
+    public function test_acces_public_a_une_recette_non_publiee_renvoie_404(): void
+    {
+        $owner = User::factory()->create();
+        $recipe = Recipe::factory()->for($owner)->create([
+            'is_public' => false,
+            'public_token' => 'jeton-non-publie',
+        ]);
+
+        $this->getJson("/api/public/recipes/{$recipe->public_token}")
+            ->assertNotFound();
+    }
+
+    public function test_acces_public_a_un_token_inconnu_renvoie_404(): void
+    {
+        $this->getJson('/api/public/recipes/token-inexistant')
+            ->assertNotFound();
+    }
+
+    public function test_acces_public_ne_necessite_pas_d_authentification(): void
+    {
+        $owner = User::factory()->create();
+        $recipe = Recipe::factory()->for($owner)->public()->create();
+
+        $this->getJson("/api/public/recipes/{$recipe->public_token}")
+            ->assertOk();
+    }
+}

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -37,19 +37,25 @@ axios.interceptors.response.use(
         return Promise.resolve(response)
     },
     error => {
-        if (error.response?.status === 401) {
-            logout()
-            window.location.reload()
-        }
-        if(error.response?.status === 404){ 
-            router.push({name: 'NotFound'})
-        }
-        if(error.response?.status === 403){ 
-            router.push({name: 'NotFound'})
-        }
-        if(error.response?.data?.message) {
-            const toast = useToast()
-            toast.error(error.response.data.message);
+        // Public recipe requests handle their own errors in the view and must
+        // not trigger logout or a redirect to the NotFound page.
+        const isPublicRequest = error.config?.url?.includes('public/recipes')
+
+        if (!isPublicRequest) {
+            if (error.response?.status === 401) {
+                logout()
+                window.location.reload()
+            }
+            if(error.response?.status === 404){ 
+                router.push({name: 'NotFound'})
+            }
+            if(error.response?.status === 403){ 
+                router.push({name: 'NotFound'})
+            }
+            if(error.response?.data?.message) {
+                const toast = useToast()
+                toast.error(error.response.data.message);
+            }
         }
         return Promise.reject(error)
     },

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -173,6 +173,14 @@ const router = createRouter({
       }
     },
     {
+      path: '/recipes/shared/:token',
+      name: 'public-recipe',
+      component: () => import('../views/PublicRecipeView.vue'),
+      meta: {
+        middleware: "public"
+      }
+    },
+    {
       path: '/my-account',
       name: 'my-account',
       component: () => import('../views/AccountView.vue'),

--- a/frontend/src/views/PublicRecipeView.vue
+++ b/frontend/src/views/PublicRecipeView.vue
@@ -1,0 +1,178 @@
+<script setup>
+import { useRoute } from 'vue-router'
+import { useQuery } from '@tanstack/vue-query'
+import axios from 'axios'
+import Loader from '../components/Loader.vue'
+import ExternalLink from '../components/icons/ExternalLink.vue'
+import MarkdownContent from '../components/MarkdownContent.vue'
+import { computed } from 'vue'
+
+const route = useRoute()
+
+const token = computed(() => route.params.token)
+
+const { data: recipe, isLoading, isError } = useQuery({
+    queryKey: computed(() => ['public-recipe', token.value]),
+    queryFn: async () => {
+        const res = await axios.get(import.meta.env.VITE_API_URL + 'public/recipes/' + token.value)
+        return res.data.data
+    },
+    enabled: computed(() => !!token.value),
+    retry: false
+})
+</script>
+
+<template>
+    <div>
+        <div v-if="isLoading">
+            <Loader loadingText="Chargement de la recette..." />
+        </div>
+
+        <div v-else-if="isError || !recipe" class="not-found">
+            <p>Cette recette n'existe pas ou n'est plus partagée publiquement.</p>
+        </div>
+
+        <div v-else class="recipe-detail">
+            <div class="header">
+                <h1>
+                    {{ recipe.name }}
+                    <a v-if="recipe.link"
+                       :href="recipe.link"
+                       target="_blank"
+                       rel="noopener noreferrer"
+                       class="external-link-icon"
+                       title="Ouvrir le lien de la recette dans un nouvel onglet">
+                        <ExternalLink />
+                    </a>
+                </h1>
+            </div>
+
+            <div v-if="recipe.tags && recipe.tags.length > 0" class="tags">
+                <span v-for="(tag, index) in recipe.tags" :key="index" class="tag">
+                    {{ tag.name }}
+                </span>
+            </div>
+
+            <div class="ingredients">
+                <h2>Ingrédients</h2>
+                <div v-if="!recipe.products || recipe.products.length === 0" class="no-ingredients">
+                    <p class="alert-info">Aucun ingrédient n'a été ajouté à cette recette.</p>
+                </div>
+                <ul v-else class="ingredients-list">
+                    <li v-for="(product, index) in recipe.products" :key="index" class="ingredient-item">
+                        <span class="ingredient-name">
+                            {{ product.name }}
+                            <span v-if="product.quantity" class="quantity">
+                                ({{ product.quantity }})
+                            </span>
+                        </span>
+                    </li>
+                </ul>
+            </div>
+
+            <div v-if="recipe.description" class="description">
+                <h2>Description</h2>
+                <MarkdownContent :source="recipe.description" />
+            </div>
+        </div>
+    </div>
+</template>
+
+<style lang="scss" scoped>
+.recipe-detail {
+    padding: 1rem;
+}
+
+h2 {
+    color: var(--color-text-alt);
+}
+
+.header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    margin-bottom: 1rem;
+    flex-wrap: wrap;
+    gap: 1rem;
+
+    h1 {
+        margin: 0;
+        flex: 1;
+        min-width: 250px;
+        display: flex;
+        align-items: baseline;
+        gap: 0.75rem;
+    }
+
+    .external-link-icon {
+        color: var(--color-primary);
+        text-decoration: none;
+        display: inline-flex;
+        align-items: center;
+
+        svg {
+            width: 1.25rem;
+            height: 1.25rem;
+        }
+
+        &:hover {
+            opacity: 0.8;
+        }
+    }
+}
+
+.tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin-bottom: 2rem;
+
+    .tag {
+        background: var(--color-1-light);
+        border-radius: 0.375rem;
+        color: var(--color-primary);
+        font-size: 0.875rem;
+        font-weight: 700;
+        padding: 0.35rem 0.65rem;
+    }
+}
+
+.description {
+    margin-bottom: 2rem;
+
+    h2 {
+        margin-bottom: 1rem;
+    }
+}
+
+.ingredients {
+    margin-bottom: 2rem;
+
+    .ingredients-list {
+        padding: 0;
+        margin: 0;
+        padding-top: 1rem;
+
+        .ingredient-item {
+            display: flex;
+            align-items: center;
+            margin-bottom: 0.75rem;
+
+            .ingredient-name {
+                flex: 1;
+                font-size: 1.1rem;
+
+                .quantity {
+                    color: var(--color-text-alt);
+                }
+            }
+        }
+    }
+}
+
+.not-found {
+    text-align: center;
+    padding: 3rem 1rem;
+    color: var(--color-text-alt);
+}
+</style>

--- a/frontend/src/views/RecipeDetailView.vue
+++ b/frontend/src/views/RecipeDetailView.vue
@@ -11,10 +11,12 @@ import TodoButton from '../components/TodoButton.vue'
 import Modal from '../components/Modal.vue'
 import MarkdownContent from '../components/MarkdownContent.vue'
 import { computed, ref } from 'vue'
+import { useToast } from 'vue-toastification'
 
 const route = useRoute()
 const router = useRouter()
 const queryClient = useQueryClient()
+const toast = useToast()
 
 const recipeId = computed(() => route.params.id)
 
@@ -88,6 +90,44 @@ const {mutate: deleteRecipeMutation} = useMutation({
 })
 
 
+
+// Public sharing state derived from the recipe payload
+const isPublic = computed(() => !!recipe.value?.is_public)
+const shareUrl = computed(() => {
+    if (!recipe.value?.public_token) {
+        return ''
+    }
+    return `${window.location.origin}/recipes/shared/${recipe.value.public_token}`
+})
+
+const { mutate: togglePublish, isLoading: isTogglingPublish } = useMutation({
+    mutationFn: async (shouldPublish) => {
+        const url = `${import.meta.env.VITE_API_URL}recipes/${recipeId.value}/publish`
+        const response = shouldPublish
+            ? await axios.post(url)
+            : await axios.delete(url)
+        return response.data
+    },
+    onSuccess: async (data) => {
+        await queryClient.invalidateQueries(['recipe', recipeId.value])
+        toast.success(data.is_public ? 'Recette rendue publique' : 'Recette rendue privée')
+    },
+    onError: (error) => {
+        console.error('Erreur lors du changement de visibilité de la recette:', error)
+    }
+})
+
+const copyShareUrl = async () => {
+    if (!shareUrl.value) {
+        return
+    }
+    try {
+        await navigator.clipboard.writeText(shareUrl.value)
+        toast.success('Lien copié dans le presse-papiers')
+    } catch (error) {
+        console.error('Impossible de copier le lien:', error)
+    }
+}
 
 const addIngredientToList = (ingredient) => {
     addIngredient(ingredient)
@@ -192,8 +232,31 @@ const handleDeleteRecipe = () => {
                 <h2>Description</h2>
                 <MarkdownContent :source="recipe.description" />
             </div>
-         
-            
+
+            <div class="share-section">
+                <h2>Partage</h2>
+                <p class="share-help">
+                    {{ isPublic
+                        ? 'Cette recette est publique : toute personne disposant du lien peut la consulter.'
+                        : 'Rendez cette recette publique pour la partager via un lien.' }}
+                </p>
+                <div v-if="isPublic && shareUrl" class="share-link">
+                    <input type="text" :value="shareUrl" readonly @focus="$event.target.select()" />
+                    <Button design="secondary" type="button" @click="copyShareUrl">
+                        Copier
+                    </Button>
+                </div>
+                <Button
+                    design="secondary"
+                    type="button"
+                    class="share-toggle"
+                    :disabled="isTogglingPublish"
+                    @click="togglePublish(!isPublic)"
+                >
+                    {{ isPublic ? 'Rendre privée' : 'Rendre publique' }}
+                </Button>
+            </div>
+
             <div class="action-buttons">
                 <Button design="secondary" @click="deleteRecipe" type="button">
                     Supprimer
@@ -275,6 +338,48 @@ h2 {
         margin-bottom: 1rem;
     }
     margin-bottom: 2rem;
+}
+
+.share-section {
+    margin-bottom: 2rem;
+
+    h2 {
+        margin-bottom: 0.5rem;
+    }
+
+    .share-help {
+        color: var(--color-text-alt);
+        font-size: 0.9rem;
+        margin: 0 0 1rem;
+    }
+
+    .share-link {
+        display: flex;
+        gap: 0.5rem;
+        align-items: stretch;
+        margin-bottom: 1rem;
+        flex-wrap: wrap;
+
+        input {
+            flex: 1;
+            min-width: 200px;
+            padding: 0.5rem 0.75rem;
+            border: 1px solid var(--color-text-alt);
+            border-radius: 0.375rem;
+            background: var(--color-background);
+            color: var(--color-text);
+            font-size: 0.9rem;
+        }
+
+        :deep(.btn) {
+            margin: 0;
+        }
+    }
+
+    .share-toggle:deep(.btn),
+    :deep(.share-toggle) {
+        margin: 0;
+    }
 }
 
 .buttons {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Objectif

Permettre à un utilisateur de rendre publiques certaines de ses recettes et de les partager via un lien, sans exposer de données privées.

## Aperçu

### Côté recette — rendre une recette publique
État initial d'une recette privée : la section « Partage » affiche le bouton **« Rendre publique »**.

[Configuration - rendre la recette publique](https://cursor.com/agents/bc-d08d231f-ae79-4a5c-8646-045c78ea62db/artifacts?path=%2Fworkspace%2F.screenshots%2Fconfig-rendre-publique.png)

### Côté recette — recette publiée
Une fois publiée, la section affiche le **lien de partage** (bouton « Copier ») et la bascule **« Rendre privée »**.

[Configuration - recette publiée avec lien de partage](https://cursor.com/agents/bc-d08d231f-ae79-4a5c-8646-045c78ea62db/artifacts?path=%2Fworkspace%2F.screenshots%2Fconfig-partage.png)

### La page publique
Accessible via `/recipes/shared/:token`, **sans authentification** ni menu de navigation. Vue en lecture seule : nom, lien externe, tags, ingrédients (nom + quantité) et description markdown. Aucune action privée.

[Page publique de la recette](https://cursor.com/agents/bc-d08d231f-ae79-4a5c-8646-045c78ea62db/artifacts?path=%2Fworkspace%2F.screenshots%2Fpage-publique.png)

## Choix d'architecture

- **Token non devinable** (`public_token` UUID) plutôt que l'`id` séquentiel, pour éviter l'énumération des recettes.
- **Endpoint public dédié** (`GET /api/public/recipes/{token}`) hors du groupe `auth:sanctum`, plutôt que de rendre conditionnel le `show` existant : aucun risque de fuite via les routes propriétaire.
- **Couche de sérialisation** (`PublicRecipeResource`) qui filtre explicitement les champs sensibles.
- Le `public_token` est **conservé** lors d'une dépublication (réactivation avec le même lien).

## Backend (`api/`)

- Migration : colonnes `is_public` (bool, indexée) et `public_token` (uuid, unique) sur `recipes`.
- `Recipe` : cast booléen, scope `public()`, méthodes `publish()` / `unpublish()`.
- `PublicRecipeResource` : expose uniquement `name`, `description`, `link`, `products` (nom + quantité) et `tags` (nom). N'expose **pas** `user_id`, `to_make`, `public_token`, ni l'état liste de courses des produits (`to_buy`, `comment`).
- `PublicRecipeController@show` : accès public par token, **404** si la recette n'existe pas ou n'est pas publiée (l'existence des recettes privées n'est jamais révélée).
- `RecipeController` : endpoints `publish` / `unpublish` protégés par `CheckOwnership`.
- Routes : `POST` / `DELETE /api/recipes/{recipe}/publish` (propriétaire) et `GET /api/public/recipes/{token}` (public).

## Frontend (`frontend/`)

- `PublicRecipeView.vue` : vue publique en lecture seule accessible via `/recipes/shared/:token` (aucune action liste de courses / édition).
- Route publique sans middleware `auth`.
- `RecipeDetailView.vue` : section « Partage » avec bascule publique/privée, affichage et copie du lien de partage.
- Intercepteur axios : les requêtes publiques ne déclenchent plus de logout ni de redirection vers `NotFound` (gestion de l'erreur directement dans la vue).

## Tests

- Nouveau `PublicRecipeTest` (8 tests) : publication, dépublication, conservation du token, refus pour un autre utilisateur, accès public filtré, 404 pour recette non publiée / token inconnu, absence d'authentification requise.
- Vérification explicite qu'aucune donnée privée (`user_id`, `to_make`, `to_buy`, `public_token`, commentaire) ne fuit dans la réponse publique.
- Suite complète : **89 tests passent**. Build et lint frontend OK (aucune nouvelle erreur introduite).

## Notes

- Les noms des produits/ingrédients de l'auteur deviennent visibles publiquement (comportement attendu), mais aucun autre attribut produit n'est exposé.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d08d231f-ae79-4a5c-8646-045c78ea62db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d08d231f-ae79-4a5c-8646-045c78ea62db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

