### PR TITLE
Configuration de l'environnement de développement (AGENTS.md)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,56 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+Griotte est un monorepo à deux applications :
+
+- `api/` : API Laravel 13 / PHP 8.3 (Fortify + Sanctum, admin Filament).
+- `frontend/` : SPA/PWA Vue 3 + Vite.
+
+### Environnement déjà en place (snapshot VM)
+
+Le snapshot contient déjà PHP 8.3 + extensions, Composer, Node 22/npm, ainsi que
+les fichiers `api/.env`, `frontend/.env` et la base SQLite `api/database/database.sqlite`
+(migrations déjà appliquées). Le script de mise à jour ne fait que rafraîchir les
+dépendances (`composer install` dans `api/`, `npm install` dans `frontend/`).
+
+Points non évidents :
+
+- **Base de données** : le dev utilise **SQLite** (`api/database/database.sqlite`), et non
+  MySQL comme dans `api/.env.example`. Après une nouvelle migration, lancer
+  `php artisan migrate` depuis `api/`. Pour repartir de zéro : `php artisan migrate:fresh`.
+  Les tests utilisent SQLite en mémoire (voir `api/phpunit.xml`), indépendamment du `.env`.
+- **Mail** : `MAIL_MAILER=log` dans `api/.env`. Aucun email n'est réellement envoyé ;
+  les liens (vérification d'email, reset password) apparaissent dans
+  `api/storage/logs/laravel.log`.
+
+### Lancer les services (dev)
+
+- API : depuis `api/`, `php artisan serve --host=0.0.0.0 --port=8000` (http://localhost:8000).
+- Frontend : depuis `frontend/`, `npm run dev -- --host` (http://localhost:5173).
+  Le `README` mentionne `npm run start`, qui n'existe pas : utiliser `npm run dev`.
+
+Les deux doivent tourner ensemble : le frontend appelle l'API via `VITE_API_URL`/`VITE_AUTH_URL`,
+et l'API n'autorise l'origine `localhost:5173` que via `SANCTUM_STATEFUL_DOMAINS` /
+`CORS_ALLOWED_ORIGINS` (déjà configurés dans `api/.env`).
+
+### Authentification / vérification d'email
+
+- Les routes métier (`api/routes/api.php`) sont derrière `auth:sanctum` **et** `verified`.
+  Un compte fraîchement inscrit doit donc être vérifié avant de créer un magasin, etc.
+- Pour vérifier un compte en dev : soit ouvrir le lien de vérification présent dans
+  `api/storage/logs/laravel.log`, soit forcer via tinker :
+  `php artisan tinker --execute="App\Models\User::where('email','...')->update(['email_verified_at'=>now()]);"`.
+- Après inscription, le frontend ne connecte pas automatiquement : passer par `/login`.
+
+### Lint / tests / build
+
+- API — lint : `./vendor/bin/pint` (le dépôt contient de nombreux écarts de style
+  préexistants ; ne pas reformater sans demande). Tests : `php artisan test` (81 tests passent).
+- Frontend — build : `npm run build`. Lint : `npm run lint` (ESLint remonte des erreurs
+  `no-unused-vars` **préexistantes** dans `src/` ; ne pas corriger sans demande). Pas de tests unitaires.
+
+### Docker
+
+`docker-compose.yml` et `dockerfile` sont réservés à la production : ne pas les utiliser
+ni les modifier pour le dev.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Objectif

Mise en place de l'environnement de développement Cloud pour Griotte (API Laravel + frontend Vue/Vite) et vérification que les deux services fonctionnent de bout en bout.

## Changements

- Ajout de `AGENTS.md` avec la section `## Cursor Cloud specific instructions` : détails non évidents sur la base SQLite en dev, le mail en `log`, la vérification d'email requise (`verified`), le lancement des services et les commandes lint/test/build.

Aucune modification du code applicatif. Les dépendances, fichiers `.env` et la base SQLite vivent dans le snapshot VM (non versionnés).

## Environnement installé

- PHP 8.3 + extensions (mbstring, xml, curl, zip, bcmath, gd, sqlite3, mysql, intl), Composer 2.
- Dépendances API (`composer install`) et frontend (`npm install`).
- `api/.env` configuré sur **SQLite** (`MAIL_MAILER=log`), clé générée, migrations appliquées.
- `frontend/.env` pointant vers l'API locale.

Script de mise à jour (rafraîchissement des dépendances au démarrage) :
```
composer install --no-interaction --no-progress --working-dir=api
npm --prefix frontend install
```

## Vérifications

- API : `php artisan test` → 81 tests OK ; `php artisan serve` sur `:8000`.
- Frontend : `npm run build` OK ; `npm run dev` sur `:5173`.
- `pint` / `eslint` : écarts de style et `no-unused-vars` **préexistants** (non modifiés).

## Démonstration « hello world »

Inscription → vérification d'email (lien dans les logs) → connexion → **création d'un magasin** via l'UI, contre l'API + SQLite réels.

[griotte_login_create_store_demo.mp4](https://cursor.com/agents/bc-f8b73060-1b65-4c67-a9aa-c369ab17aebd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgriotte_login_create_store_demo.mp4)

[Liste des magasins avec le magasin créé](https://cursor.com/agents/bc-f8b73060-1b65-4c67-a9aa-c369ab17aebd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgriotte_stores_list_final.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f8b73060-1b65-4c67-a9aa-c369ab17aebd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f8b73060-1b65-4c67-a9aa-c369ab17aebd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

